### PR TITLE
Remove focus outline from missed dropdown menu elements

### DIFF
--- a/src/app/_components/Layout/DrodpownMenu/DropdownMenu.tsx
+++ b/src/app/_components/Layout/DrodpownMenu/DropdownMenu.tsx
@@ -48,7 +48,7 @@ export const DropdownMenu = ({ title, children, classNameCustom }: Props) => {
               ref={buttonRef}
               className={twMerge(
                 `flex justify-between items-center text-lg font-medium 
-                hover:text-colr-mvx-teal duration-200`,
+                hover:text-colr-mvx-teal duration-200 outline-none focus:outline-none`,
                 classNameCustom,
               )}
             >
@@ -71,9 +71,9 @@ export const DropdownMenu = ({ title, children, classNameCustom }: Props) => {
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <Menu.Items className="absolute">
-              <div className="pt-2 bg-transparent"></div>
-              <div className="divide-gray-100  bg-white divide-y rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+            <Menu.Items className="absolute outline-none focus:outline-none">
+              <div className="pt-2 bg-transparent outline-none focus:outline-none"></div>
+              <div className="divide-gray-100 bg-white divide-y rounded-md shadow-lg ring-1 ring-black ring-opacity-5 outline-none focus:outline-none">
                 {children}
               </div>
             </Menu.Items>


### PR DESCRIPTION
#8 
Fix to https://github.com/GhostVerseOrg/VladFrontend/issues/8
remove focus effect on all elements of dropdown